### PR TITLE
Fix regression in version 2.0.26

### DIFF
--- a/JenkinsWiki.adoc
+++ b/JenkinsWiki.adoc
@@ -41,8 +41,8 @@ termination"
 [SpotinstPlugin-Versionhistory]
 == Version history
 
-[SpotinstPlugin-Version2.0.26(Oct5,2020)]
-=== Version 2.0.26 (Oct 5, 2020)
+[SpotinstPlugin-Version2.0.27(Oct25,2020)]
+=== Version 2.0.27 (Oct 25, 2020)
 
 * Add Public and private IP labels to the node description
 * Add AWS instance types

--- a/src/main/java/hudson/plugins/spotinst/cloud/PendingInstance.java
+++ b/src/main/java/hudson/plugins/spotinst/cloud/PendingInstance.java
@@ -54,8 +54,7 @@ public class PendingInstance {
 
     public enum StatusEnum {
         PENDING("PENDING"),
-        INSTANCE_INITIATING("INSTANCE_INITIATING"),
-        UPDATING("UPDATING");
+        INSTANCE_INITIATING("INSTANCE_INITIATING");
 
         private String name;
 

--- a/src/main/java/hudson/plugins/spotinst/slave/SlaveInstanceDetails.java
+++ b/src/main/java/hudson/plugins/spotinst/slave/SlaveInstanceDetails.java
@@ -1,0 +1,65 @@
+package hudson.plugins.spotinst.slave;
+
+import hudson.plugins.spotinst.model.aws.AwsGroupInstance;
+import hudson.plugins.spotinst.model.azure.AzureGroupInstance;
+import hudson.plugins.spotinst.model.gcp.GcpGroupInstance;
+
+/**
+ * @author Caduri Katzav
+ */
+public class SlaveInstanceDetails {
+    //region Members
+    private final String instanceId;
+    private final String privateIp;
+    private final String publicIp;
+    //endregion
+
+    //region Constructor
+    public SlaveInstanceDetails(String instanceId, String privateIp, String publicIp) {
+        this.instanceId = instanceId;
+        this.privateIp = privateIp;
+        this.publicIp = publicIp;
+    }
+    //endregion
+
+    //region Static Methods
+    public static SlaveInstanceDetails build(AwsGroupInstance instance) {
+        SlaveInstanceDetails retVal =
+                new SlaveInstanceDetails(instance.getInstanceId(), instance.getPrivateIp(), instance.getPublicIp());
+        return retVal;
+    }
+
+    public static SlaveInstanceDetails build(AzureGroupInstance instance) {
+        SlaveInstanceDetails retVal =
+                new SlaveInstanceDetails(instance.getInstanceId(), instance.getPrivateIp(), instance.getPublicIp());
+        return retVal;
+    }
+
+    public static SlaveInstanceDetails build(GcpGroupInstance instance) {
+        SlaveInstanceDetails retVal =
+                new SlaveInstanceDetails(instance.getInstanceName(), instance.getPrivateIpAddress(),
+                                         instance.getPublicIpAddress());
+        return retVal;
+    }
+
+    public static SlaveInstanceDetails build(SpotinstSlave slave) {
+        SlaveInstanceDetails retVal =
+                new SlaveInstanceDetails(slave.getInstanceId(), slave.getPrivateIp(), slave.getPublicIp());
+        return retVal;
+    }
+    //endregion
+
+    //region Getters & Setters
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    public String getPrivateIp() {
+        return privateIp;
+    }
+
+    public String getPublicIp() {
+        return publicIp;
+    }
+    //endregion
+}

--- a/src/main/java/hudson/plugins/spotinst/slave/SpotinstComputer.java
+++ b/src/main/java/hudson/plugins/spotinst/slave/SpotinstComputer.java
@@ -1,6 +1,5 @@
 package hudson.plugins.spotinst.slave;
 
-import hudson.plugins.spotinst.slave.SpotinstSlave;
 import hudson.slaves.SlaveComputer;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;

--- a/src/main/java/hudson/plugins/spotinst/slave/SpotinstSlave.java
+++ b/src/main/java/hudson/plugins/spotinst/slave/SpotinstSlave.java
@@ -32,15 +32,13 @@ public class SpotinstSlave extends Slave {
     private String            workspaceDir;
     private String            groupUrl;
     private SlaveUsageEnum    usage;
-    private String            privateIp;
-    private String            publicIp;
     private Date              createdAt;
     private BaseSpotinstCloud spotinstCloud;
     //endregion
 
     //region Constructor
     public SpotinstSlave(BaseSpotinstCloud spotinstCloud, String name, String elastigroupId, String instanceId,
-                         String instanceType, String privateIp, String publicIp, String label, String idleTerminationMinutes, String workspaceDir,
+                         String instanceType, String label, String idleTerminationMinutes, String workspaceDir,
                          String numOfExecutors, Mode mode, String tunnel, String vmargs,
                          List<NodeProperty<?>> nodeProperties) throws Descriptor.FormException, IOException {
 
@@ -51,8 +49,6 @@ public class SpotinstSlave extends Slave {
         this.elastigroupId = elastigroupId;
         this.instanceType = instanceType;
         this.instanceId = instanceId;
-        this.privateIp = privateIp;
-        this.publicIp = publicIp;
         this.workspaceDir = workspaceDir;
         this.usage = SlaveUsageEnum.fromMode(mode);
         this.createdAt = new Date();
@@ -100,21 +96,27 @@ public class SpotinstSlave extends Slave {
     }
 
     public String getPrivateIp() {
-        return privateIp;
+        String               retVal          = null;
+        String               instanceId      = getInstanceId();
+        SlaveInstanceDetails instanceDetails = spotinstCloud.getSlaveDetails(instanceId);
+
+        if (instanceDetails != null) {
+            retVal = instanceDetails.getPrivateIp();
+        }
+
+        return retVal;
     }
 
     public String getPublicIp() {
-        return publicIp;
-    }
-    //endregion
+        String               retVal          = null;
+        String               instanceId      = getInstanceId();
+        SlaveInstanceDetails instanceDetails = spotinstCloud.getSlaveDetails(instanceId);
 
-    //region Setters
-    public void setPrivateIp(String privateIp) {
-        this.privateIp = privateIp;
-    }
+        if (instanceDetails != null) {
+            retVal = instanceDetails.getPublicIp();
+        }
 
-    public void setPublicIp(String publicIp) {
-        this.publicIp = publicIp;
+        return retVal;
     }
     //endregion
 
@@ -154,14 +156,13 @@ public class SpotinstSlave extends Slave {
         return Objects.equals(instanceId, that.instanceId) && Objects.equals(instanceType, that.instanceType) &&
                Objects.equals(elastigroupId, that.elastigroupId) && Objects.equals(workspaceDir, that.workspaceDir) &&
                Objects.equals(groupUrl, that.groupUrl) && usage == that.usage &&
-               Objects.equals(privateIp, that.privateIp) && Objects.equals(publicIp, that.publicIp) &&
                Objects.equals(createdAt, that.createdAt) && Objects.equals(spotinstCloud, that.spotinstCloud);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), instanceId, instanceType, elastigroupId, workspaceDir, groupUrl, usage,
-                            privateIp, publicIp, createdAt, spotinstCloud);
+                            createdAt, spotinstCloud);
     }
     //endregion
 


### PR DESCRIPTION
We need to update agent details after adding it to jenkins because some info(i.e public ip)
is not available from creation.
To do that we used `setNodes`(also tried `setNode` using computer) and it caused jenkins to close the connection to the agent
we couldn't find why its happening or if we are using it wrong

Instead we are saving a copy of the instances details in `BaseSpotinstCloud` and the agent get these details from there