### PR TITLE
Avoid starvation

### DIFF
--- a/JenkinsWiki.adoc
+++ b/JenkinsWiki.adoc
@@ -41,6 +41,11 @@ termination"
 [SpotinstPlugin-Versionhistory]
 == Version history
 
+[SpotinstPlugin-Version2.1.8(Jun1,2021)]
+=== Version 2.1.8 (Jun 1, 2021)
+
+* Add timeout to RestClient to handle process starvation in edge-cases
+
 [SpotinstPlugin-Version2.1.7(Feb10,2021)]
 === Version 2.1.7 (Feb 10, 2021)
 

--- a/src/main/java/hudson/plugins/spotinst/api/infra/RestClient.java
+++ b/src/main/java/hudson/plugins/spotinst/api/infra/RestClient.java
@@ -2,6 +2,7 @@ package hudson.plugins.spotinst.api.infra;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.*;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
@@ -17,6 +18,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+
+import static hudson.plugins.spotinst.common.Constants.*;
 
 public class RestClient {
 
@@ -64,7 +67,15 @@ public class RestClient {
     private static RestResponse sendRequest(HttpUriRequest urlRequest) throws ApiException {
         RestResponse retVal = null;
 
-        HttpClient httpclient = HttpClientBuilder.create().build();
+        RequestConfig.Builder configBuilder = RequestConfig.custom();
+
+        configBuilder.setConnectTimeout(REST_CLIENT_CONNECT_TIMEOUT_IN_SECONDS * 1000);
+        configBuilder.setConnectionRequestTimeout(REST_CLIENT_CONNECTION_REQUEST_TIMEOUT_IN_SECONDS * 1000);
+        configBuilder.setSocketTimeout(REST_CLIENT_SOCKET_TIMEOUT_IN_SECONDS * 1000);
+
+        RequestConfig config = configBuilder.build();
+
+        HttpClient httpclient = HttpClientBuilder.create().setDefaultRequestConfig(config).build();
 
         CloseableHttpResponse response = null;
         try {

--- a/src/main/java/hudson/plugins/spotinst/common/Constants.java
+++ b/src/main/java/hudson/plugins/spotinst/common/Constants.java
@@ -4,7 +4,10 @@ package hudson.plugins.spotinst.common;
  * Created by ohadmuchnik on 21/03/2017.
  */
 public class Constants {
-    public static final Integer PENDING_INSTANCE_TIMEOUT_IN_MINUTES       = 10;
-    public static final Integer AZURE_PENDING_INSTANCE_TIMEOUT_IN_MINUTES = 15;
-    public static final Integer SLAVE_OFFLINE_THRESHOLD_IN_MINUTES        = 15;
+    public static final Integer PENDING_INSTANCE_TIMEOUT_IN_MINUTES               = 10;
+    public static final Integer AZURE_PENDING_INSTANCE_TIMEOUT_IN_MINUTES         = 15;
+    public static final Integer SLAVE_OFFLINE_THRESHOLD_IN_MINUTES                = 15;
+    public static final Integer REST_CLIENT_CONNECT_TIMEOUT_IN_SECONDS            = 120;
+    public static final Integer REST_CLIENT_CONNECTION_REQUEST_TIMEOUT_IN_SECONDS = 120;
+    public static final Integer REST_CLIENT_SOCKET_TIMEOUT_IN_SECONDS             = 120;
 }


### PR DESCRIPTION
In some edge-cases -- especially DNS issues -- the RestClient will not get a response in a timely manner, or even never. This can lead to important processes like SyncInstances to not run because its thread is stuck.

The timeout added to the RestClient class should verify that this doesn't happen.


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did


